### PR TITLE
Ordinal relationship improvement suggestions

### DIFF
--- a/class-metamodel/relationship-subsystem/rel.mls
+++ b/class-metamodel/relationship-subsystem/rel.mls
@@ -24,7 +24,6 @@ nodes
     Relationship 12-13,9
     Generalization 11,6
     Ordinal Relationship/2 11,8
-    Identifier 7,8
     Identifier Attribute 9-10,9
     Class In Lineage 6-7,4
     Lineage 5,5
@@ -37,10 +36,8 @@ connectors
     +R101 : +/1 t*|Class.2 : +/1 b|Generalization, r|Facet
     +R102 : l|Facet { r|Subclass, r|Superclass }
     -R103 : -/1 t|Superclass : +/1 l-1|Generalization
-    -R104.2 : -/3 b-2|Ordinal Relationship : -/3 r|Class.2
     +R105 : t|Asymmetric Perspective  { b|T Perspective, b|P Perspective }
     +R106 : +/1 r|Ordinal Relationship : +/1 t|Identifier Attribute
-    +R107 : +/2 b|Ordinal Relationship : +/2 t*|Identifier
     -R110 : +/1 r|Perspective : -/1 b|Class
     +R116 : +/1 t|Minimal Partition : +/1 l+2|Generalization
     +R117 : -/2 l*|Subclass : -/2 r+2|Minimal Partition

--- a/class-metamodel/relationship-subsystem/rel.xmm
+++ b/class-metamodel/relationship-subsystem/rel.xmm
@@ -60,12 +60,6 @@ attributes
     Domain {I, R100, R103}
     Superclass {R103}
 --
-class Identifier <import:Class And Attribute>
-attributes
-    Number {I}
-    Class {I}
-    Domain {I}
---
 class Identifier Attribute <import:Class And Attribute>
 attributes
     Identifier {I}
@@ -94,10 +88,10 @@ attributes
 class Ordinal Relationship
 attributes
     Rnum {I, R100}
-    Domain {I, R100, R104, R106, R107}
-    Ranked class {R104, R106, R107}
+    Domain {I, R100, R106}
+    Ranked class {R106}
     Ranking attribute {R106}
-    Ranking identifier {R107, R106}
+    Ranking identifier {R106}
     Ascending perspective : Phrase Name
     Descending perspective : Phrase Name
 --
@@ -169,10 +163,6 @@ relationships
     is required by, 1 Generalization
     requires, 1 Superclass
 --
-    R104
-    ranks instances by value in, 1 Class
-    has instances ranked in value by, Mc Ordinal Relationship
---
     R105
     Asymmetric Perspective +
         T Perspective
@@ -181,10 +171,6 @@ relationships
     R106
     is ranked by, 1 Identifier Attribute
     is used to rank, 1c Ordinal Relationship
---
-    R107
-    scopes ranking in, Mc Ordinal Relationship
-    has ranking scoped by, 1 Identifier
 --
     R110
     is standpoint of, Mc Perspective

--- a/class-metamodel/relationship-subsystem/rel.xmm
+++ b/class-metamodel/relationship-subsystem/rel.xmm
@@ -180,7 +180,7 @@ relationships
 --
     R106
     is ranked by, 1 Identifier Attribute
-    is used to rank, Mc Ordinal Relationship
+    is used to rank, 1c Ordinal Relationship
 --
     R107
     scopes ranking in, Mc Ordinal Relationship


### PR DESCRIPTION
Two improvement suggestions and commits:
1. Changed the relationship multiplicity from many to one on the “Ordinal Relationship” side of R106.
    This in compliance with statement in wiki for R107:
    “An Identifier could participate in more than one Ordinal Relationship (all of which would have to be on the same Class) if, and only if, the choice of Ranking attribute is different in each Ordinal Relationship.“
2. R104 and R107 is removed from the Relationship subsystem. They are not providing any extra information not already provided by R106.

Note, that the pdf model file is not generated..  